### PR TITLE
Add stylelint-junit-formatter package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN npm install -g eslint \
     stylelint \
     stylelint-no-browser-hacks \
     stylelint-config-standard \
+    stylelint-junit-formatter \
     && npm info "$PKG@latest" peerDependencies --json \
     | command sed 's/[\{\},]//g ; s/: /@/g' \
     | xargs npm install --save-dev "$PKG@latest"


### PR DESCRIPTION
We can do something like this:
`sh "stylelint '${params.CUSTOM_MODULES}/**/*.css' --config=web/core/.stylelintrc.json --config-basedir=/usr/local/lib --custom-formatter=/usr/local/lib/node_modules/stylelint-junit-formatter > ${REPORTS}/styelint.xml"`

The only issue with this package is that it will return an error if no css or sass files are found.  We might not want to add to the pipeline until we have css or sass files to test.